### PR TITLE
Add support for Python 3 f-string syntax

### DIFF
--- a/Mariana.xml
+++ b/Mariana.xml
@@ -4,7 +4,7 @@ Notepad++ Custom Style
 
  Style name:    Mariana
      Author:    Sandeep Pandey
-       Date:    2018-10-21 (last changed 2019-10-30)
+       Date:    2018-10-21 (last changed 2022-10-06)
   Languages:    html, css, javascript, php, bash, batch, sql, xml, json, python, java, c++, csharp, yaml, rust and everything else more or less...
        Info:    Mariana - Sublime Text 3 theme for Notepad++
 				Inspired by the Sublime Text 3's Mariana theme, derived from the excellent work of Chris Kempson and Dmitri Voronianski
@@ -942,6 +942,10 @@ Notepad++ Custom Style
 			<WordsStyle name="IDENTIFIER" styleID="11" fgColor="D8DEE9" bgColor="343D46" fontName="" fontStyle="0" fontSize="" />
 			<WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="A6ACB9" bgColor="343D46" fontName="" fontStyle="0" fontSize="" />
 			<WordsStyle name="DECORATOR" styleID="15" fgColor="6699CC" bgColor="343D46" fontName="" fontStyle="0" fontSize="" />
+			<WordsStyle name="F STRING" styleID="16" fgColor="99C794" bgColor="343D46" fontName="" fontStyle="0" fontSize="" />
+			<WordsStyle name="F CHARACTER" styleID="17" fgColor="99C794" bgColor="343D46" fontName="" fontStyle="0" fontSize="" />
+			<WordsStyle name="F TRIPLE" styleID="18" fgColor="99C794" bgColor="343D46" fontName="" fontStyle="0" fontSize="" />
+			<WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="99C794" bgColor="343D46" fontName="" fontStyle="0" fontSize="" />
 		</LexerType>
 		<LexerType name="r" desc="R" ext="">
 			<WordsStyle name="DEFAULT" styleID="0" fgColor="D8DEE9" bgColor="343D46" fontName="" fontStyle="0" fontSize="" />


### PR DESCRIPTION
Add syntax highlighting for Python 3's f-strings, using the `<LexerType>` section's `<WordStyle ...>` tag attributes: "F STRING", "F CHARACTER", "F TRIPLE", and "F TRIPLEDOUBLE".

The color scheme for these tags is set to be identical to the non f-string version of the "STRING" tag.

The "F TRIPLE" and "F TRIPLEDOUBLE" tags are set to follow the "STRING" tag theming instead of the "TRIPLE"/"TRIPLEDOUBLE" tags, because they are typically used for string assignments and formatting, whereas the "TRIPLE" and "TRIPLEDOUBLE" tags are themed to be used for Python docstring literals and comments.

Visual comparison of the changes (different from line 7 onwards):

Before                     |  After
:-------------------------:|:-------------------------:
![syntax_before](https://user-images.githubusercontent.com/6595066/194417506-b4ecf978-5936-42bb-8df3-4723bb16692e.png)  |  ![syntax_after](https://user-images.githubusercontent.com/6595066/194417644-87458873-c244-484d-b6d1-58253bddb41c.png)

